### PR TITLE
UX tweaks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = "utf-8"
+
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ See below for details on [deployment on Heroku](#heroku-deployment), [manual dep
 
 | Supported 	                        | Unsupported 	                      |
 |:------------------------------------|:----------------------------- 	    |
-| `<%subject%>`              	        | `<%asm_group_unsubscribe_url%>` 	
-| `<%body%>` 	                        | `<%asm_preferences_url%>` 	
-| `<%asm_global_unsubscribe_url%>`*   | |
+| `<%subject%>`              	        | `<%asm_group_unsubscribe_url%>`
+| `<%body%>` 	                        | `<%asm_preferences_url%>`
+| `<%asm_global_unsubscribe_url%>`*   | Sections |
 | Custom delimited variables**   | |
 
 
@@ -75,11 +75,11 @@ Request:
 POST /api/translate HTTP/1.1
 Content-Type: application/json
 
-sendgridTemplate: "string",
+sendgridTemplate: "SendGrid template content",
 options: {
-  isCampaign: "boolean",
-  startingDelimiter: "string",
-  endingDelimiter: "string"
+  isCampaign: false,
+  startingDelimiter: "%",
+  endingDelimiter: "%"
 }
 
 ```
@@ -91,7 +91,10 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 
 {
-  "sparkPostTemplate": "string"
+  "sparkPostTemplate": "Translated template content",
+  "warnings": [
+    "<%asm_group_unsubscribe_url%> is unsupported. Treating a normal substitution variable."
+  ]
 }
 ```
 
@@ -108,15 +111,15 @@ POST /api/migrate HTTP/1.1
 Content-Type: application/json
 
 {
-  sendgridAPIKey: "string",
-  sendgridTemplateId: "string",
-  sparkPostAPIKey: "string",
+  sendgridAPIKey: "your-sendgrid-api-key",
+  sendgridTemplateId: "your-sendgrid-template-or-campaign-id",
+  sparkPostAPIKey: "your-sparkpost-api-key",
   options: {
-    useHerokuSPAPIKey: "boolean",
-    isSendgridCampaign: "boolean",
-    useSandboxDomain: "boolean",
-    startingDelimiter: "string"
-    endingDelimiter: "string"
+    useHerokuSPAPIKey: false,
+    isSendgridCampaign: true,
+    useSandboxDomain: true,
+    startingDelimiter: "%"
+    endingDelimiter: "%"
   }
 }
 
@@ -129,7 +132,10 @@ HTTP/1.1 200 OK
 Content-Type: application/json
 
 {
-  "result": true
+  "result": true,
+  "warnings": [
+    "<%asm_group_unsubscribe_url%> is unsupported. Treating a normal substitution variable."
+  ]
 }
 ```
 

--- a/lib/campaign.js
+++ b/lib/campaign.js
@@ -4,41 +4,47 @@ let _ = require('lodash')
   , parseOneAddress = require('email-addresses').parseOneAddress
   , version = require('../package.json').version
   , translator = require('../lib/translator')
+  , generateWarnings = require('./utils').generateWarnings
   , rules = [
-  [/\[(Sender_[A-Za-z]+)]/g, "{{ $1 or '' }}"],
-  //[/\[Sender_Name]/g, "{{ Sender_Name or '' }}"],
-  //[/\[Sender_Address]/g, "{{ Sender_Address or '' }}"],
-  //[/\[Sender_City]/g, "{{ Sender_City or '' }}"],
-  //[/\[Sender_State]/g, "{{ Sender_State or '' }}"],
-  //[/\[Sender_Zip]/g, "{{ Sender_Zip or '' }}"],
-  [/\[Unsubscribe]/g, '<a href="?" data-msys-unsubscribe="1">unsubs</a>'],
-  [/\[Weblink]/g, "{{ Weblink or '' }}"],
+    [/\[Sender_(Name|Address|City|State|Zip)]/gi, "{{ Sender_$1 or '' }}"],
+    [/\[Unsubscribe]/gi, '<a href="?" data-msys-unsubscribe="1">Unsubscribe</a>'],
+    [/\[Unsubscribe_Preferences\]/gi, "{{ Unsubscribe_Preferences or '' }}"],
+    [/\[Weblink]/gi, "{{ Weblink or '' }}"],
 
-  /* ORDERS of following rules are IMPORTANT */
-  [/\[%email%]/g, "{{ address.email }}"],
-  [/\[%([a-zA-Z0-9_]+)%]/g, function (match, fieldName) { //custom field without default value
-    return `{{ ${fieldName.trim()} }}`;
-  }],
-  [/\[%([a-zA-Z0-9_]+)\s+\|(.*[^\s]?)%]/g, function (match, fieldName, defaultValue) { //custom field with default value
-    defaultValue = defaultValue.replace(/(^\"|\')|(\"|\'$)/g, "").trim(); //trim beginning/trailing quotes
-    return `{{ ${fieldName.trim()} or '${defaultValue}' }}`;
-  }]
-];
+    /* ORDERS of following rules are IMPORTANT */
+    [/\[%email%]/g, "{{ address.email }}"],
+    [/\[%([a-zA-Z0-9_]+)%]/g, function (match, fieldName) { //custom field without default value
+      return `{{ ${fieldName.trim()} }}`;
+    }],
+    [/\[%([a-zA-Z0-9_]+)\s+\|(.*[^\s]?)%]/g, function (match, fieldName, defaultValue) { //custom field with default value
+      defaultValue = defaultValue.replace(/(^\"|\')|(\"|\'$)/g, "").trim(); //trim beginning/trailing quotes
+      return `{{ ${fieldName.trim()} or '${defaultValue}' }}`;
+    }]
+  ]
+  , unsupportedSyntax = [
+    [/\[Unsubscribe_Preferences\]/i, '[Unsubscribe_Preferences] is unsupported. Treating as a normal substitution variable.']
+  ];
 
 
 function translateText(templateText) {
-  return translator.translate(rules, templateText)
+  let warnings = generateWarnings(templateText, unsupportedSyntax);
+  return {
+    text: translator.translate(rules, templateText),
+    warnings: warnings
+  };
 }
 
 function getFrom(template, options) {
-  let fromEmail = _.get(template, 'from.email')
+  let fromName = _.get(template, 'from.name')
+    , fromEmail = _.get(template, 'from.email')
     , localPart = _.get(parseOneAddress(fromEmail), 'local', 'imported');
 
   if (options.useSandboxDomain || !fromEmail) {
     fromEmail = `${localPart}@${options.sandboxDomain}`;
   }
+
   return {
-    name: localPart,
+    name: fromName || localPart,
     email: fromEmail
   }
 }
@@ -48,14 +54,24 @@ function translate(template, options) {
     id: template.id.toString(),
     name: template.name,
     description: 'Translated by sendgrid2sparkpost ' + version
-  };
+  }
+    , htmlResult
+    , textResult
+    , subjectResult;
 
-  translatedTemplate.html = translateText(template.html);
-  translatedTemplate.text = translateText(template.text);
-  translatedTemplate.subject = translateText(template.subject);
+  textResult = translateText(template.text, options);
+  htmlResult = translateText(template.html, options);
+  subjectResult = translateText(template.subject, options);
+
+  translatedTemplate.html = htmlResult.text;
+  translatedTemplate.text = textResult.text;
+  translatedTemplate.subject = subjectResult.text;
   translatedTemplate.from = getFrom(template, options);
 
-  return translatedTemplate;
+  return {
+    template: translatedTemplate,
+    warnings: subjectResult.warnings.concat(htmlResult.warnings, textResult.warnings)
+  };
 }
 
 module.exports = {

--- a/lib/transactional.js
+++ b/lib/transactional.js
@@ -1,15 +1,27 @@
 'use strict';
 let _ = require('lodash')
   , translator = require('../lib/translator')
-  , version = require('../package.json').version,
-  rules = [
+  , version = require('../package.json').version
+  , rules = [
+    [/<%asm_group_unsubscribe_url%>/, '{{asm_group_unsubscribe_url}}'],
+    [/<%asm_preferences_url%>/, '{{asm_preferences_url}}'],
     [/<%subject%>/, '{{ subject }}'],
     [/<%body%>/, '{{ body }}'],
-    [/<%asm_global_unsubscribe_url%>/g, '<a href="?" data-msys-unsubscribe="1">unsubs</a>']
+    [/<%asm_global_unsubscribe_url%>/g, '<a href="?" data-msys-unsubscribe="1">Unsubscribe</a>']
+  ]
+  , unsupportedSyntax = [
+    [/<%asm_group_unsubscribe_url%>/, "Warning: asm_group_unsubscribe_url tag is unsupported. Treating as a normal substitution variable." ],
+    [/<%asm_preferences_url%>/, "Warning: asm_preferences_url tag is unsupported. Treating as a normal substitution variable." ]
   ];
 
+function generateWarnings(content) {
+  let foundInContent = unsupportedSyntax.filter(syntax => syntax[0].test(content));
+  let warnings = foundInContent.map(result => result[1]);
+  return warnings;
+}
 
 function translateText(content, opts) {
+  let warnings = generateWarnings(content);
   opts = opts || {};
   content = translator.translate(rules, content);
 
@@ -17,7 +29,10 @@ function translateText(content, opts) {
     content = translator.translateCustomDelimited(content, opts.startingDelimiter, opts.endingDelimiter);
   }
 
-  return content;
+  return {
+    text: content,
+    warnings: warnings
+  };
 }
 
 function translate(template, opts) {
@@ -26,22 +41,31 @@ function translate(template, opts) {
     id: template.id.toString(),
     name: template.name,
     description: 'Translated by sendgrid2sparkpost ' + version
-  };
+  }
+  , textResult
+  , htmlResult
+  , subjectResult;
 
   if(!opts.sandboxDomain) {
     throw new Error('No sandbox domain!');
   }
 
-  translatedTemplate.html = translateText(template.html, opts);
-  translatedTemplate.text = translateText(template.text, opts);
-  translatedTemplate.subject = translateText(template.subject, opts);
+  textResult = translateText(template.text, opts);
+  htmlResult = translateText(template.html, opts);
+  subjectResult = translateText(template.subject, opts);
+
+  translatedTemplate.html = htmlResult.text;
+  translatedTemplate.text = textResult.text;
+  translatedTemplate.subject = subjectResult.text;
   translatedTemplate.from = {
     name: 'Imported',
     email: `imported@${opts.sandboxDomain}`
   };
 
-  return translatedTemplate;
-
+  return {
+    template: translatedTemplate,
+    warnings: subjectResult.warnings.concat(htmlResult.warnings, textResult.warnings)
+  };
 }
 
 module.exports = {

--- a/lib/transactional.js
+++ b/lib/transactional.js
@@ -2,26 +2,21 @@
 let _ = require('lodash')
   , translator = require('../lib/translator')
   , version = require('../package.json').version
+  , generateWarnings = require('./utils').generateWarnings
   , rules = [
-    [/<%asm_group_unsubscribe_url%>/, '{{asm_group_unsubscribe_url}}'],
-    [/<%asm_preferences_url%>/, '{{asm_preferences_url}}'],
+    [/<%asm_group_unsubscribe_url%>/, '{{ asm_group_unsubscribe_urli }}'],
+    [/<%asm_preferences_url%>/, '{{ asm_preferences_url }}'],
     [/<%subject%>/, '{{ subject }}'],
     [/<%body%>/, '{{ body }}'],
     [/<%asm_global_unsubscribe_url%>/g, '<a href="?" data-msys-unsubscribe="1">Unsubscribe</a>']
   ]
   , unsupportedSyntax = [
-    [/<%asm_group_unsubscribe_url%>/, "Warning: asm_group_unsubscribe_url tag is unsupported. Treating as a normal substitution variable." ],
-    [/<%asm_preferences_url%>/, "Warning: asm_preferences_url tag is unsupported. Treating as a normal substitution variable." ]
+    [/<%asm_group_unsubscribe_url%>/, "&lt;%asm_group_unsubscribe_url%&gt; is unsupported. Treating as a normal substitution variable." ],
+    [/<%asm_preferences_url%>/, "&lt;%asm_preferences_url%&gt; is unsupported. Treating as a normal substitution variable." ]
   ];
 
-function generateWarnings(content) {
-  let foundInContent = unsupportedSyntax.filter(syntax => syntax[0].test(content));
-  let warnings = foundInContent.map(result => result[1]);
-  return warnings;
-}
-
 function translateText(content, opts) {
-  let warnings = generateWarnings(content);
+  let warnings = generateWarnings(content, unsupportedSyntax);
   opts = opts || {};
   content = translator.translate(rules, content);
 
@@ -42,9 +37,9 @@ function translate(template, opts) {
     name: template.name,
     description: 'Translated by sendgrid2sparkpost ' + version
   }
-  , textResult
-  , htmlResult
-  , subjectResult;
+    , textResult
+    , htmlResult
+    , subjectResult;
 
   if(!opts.sandboxDomain) {
     throw new Error('No sandbox domain!');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,11 @@
+'use strict';
+
+function generateWarnings(content, warningTests) {
+  let foundInContent = warningTests.filter(syntax => syntax[0].test(content));
+  let warnings = foundInContent.map(result => result[1]);
+  return warnings;
+}
+
+module.exports = {
+  generateWarnings: generateWarnings
+};

--- a/routes/migrate.js
+++ b/routes/migrate.js
@@ -96,7 +96,6 @@ router.post('/', function (req, res) {
       return res.json({result: true, response: result, warnings: warnings});
     })
     .catch(err => {
-      console.dir(err);
       res.clientError(err.message);
     });
 });

--- a/routes/migrate.js
+++ b/routes/migrate.js
@@ -66,8 +66,10 @@ function translate(req, templateData) {
     }
   });
 }
+
 router.post('/', function (req, res) {
-  let spAPIKey = getApiKey(req);
+  let spAPIKey = getApiKey(req)
+    , warnings;
 
   return validate(req)
     .then(() => {
@@ -77,10 +79,11 @@ router.post('/', function (req, res) {
       return translate(req, templateData);
     })
     .then((translatedTemplate) => {
-      return sparkpost.save(translatedTemplate, spAPIKey);
+      warnings = translatedTemplate.warnings;
+      return sparkpost.save(translatedTemplate.template, spAPIKey);
     })
     .then((result) => {
-      return res.json({result: true, response: result});
+      return res.json({result: true, response: result, warnings: warnings});
     })
     .catch(err => {
       console.log(err);

--- a/routes/migrate.js
+++ b/routes/migrate.js
@@ -31,12 +31,10 @@ function validate(req) {
 }
 
 function getApiKey(req) {
-
   if (process.env.SPARKPOST_API_KEY) {
     return resolve(process.env.SPARKPOST_API_KEY);
   }
   return req.body.sparkPostAPIKey;
-
 }
 
 function getSandboxDomain() {
@@ -101,7 +99,6 @@ router.post('/', function (req, res) {
       console.dir(err);
       res.clientError(err.message);
     });
-
 });
 
 module.exports = router;

--- a/routes/translate.js
+++ b/routes/translate.js
@@ -16,7 +16,6 @@ router.post('/', function (req, res) {
     return;
   }
 
-
   try {
     if (isSendgridCampaign) {
       translatedTemplate = campaign.translateText(req.body.sendgridTemplate);

--- a/routes/translate.js
+++ b/routes/translate.js
@@ -24,7 +24,7 @@ router.post('/', function (req, res) {
       translatedTemplate = transactional.translateText(req.body.sendgridTemplate, _.pick(options, ['startingDelimiter', 'endingDelimiter']));
     }
 
-    res.json({sparkPostTemplate: translatedTemplate});
+    res.json({sparkPostTemplate: translatedTemplate.text, warnings: translatedTemplate.warnings});
 
   } catch (err) {
     if (!errors.errorResponse(err, res)) {

--- a/static/index.html
+++ b/static/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+  <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -17,95 +17,95 @@
     <link rel="icon" href="favicon-32.png" sizes="32x32"/>
     <link rel="icon" href="favicon-48.png" sizes="48x48"/>
     <link rel="shortcut icon" href="favicon.ico"/>
-</head>
-<body>
-<div class="titlebar">
-    <a href="https://www.sparkpost.com">
-        <img class="navbar-logo" src="https://developers.sparkpost.com/images/logo-sparkpost-white.png" alt="SparkPost"
-             width="150">
-    </a>
-</div>
-<div class="container-fluid">
-    <div class="jumbotron">
+  </head>
+  <body>
+    <div class="titlebar">
+      <a href="https://www.sparkpost.com">
+        <img class="navbar-logo" src="https://developers.sparkpost.com/images/logo-sparkpost-white.png" alt="SparkPost" width="150">
+      </a>
+    </div>
+    <div class="container-fluid">
+      <div class="jumbotron">
         <h2>SendGrid Template Translation</h2>
         <p>
-            <small>This is a SendGrid to SparkPost template translation service. From here you can translate a template
-                from file or migrate one directly from your SendGrid account into SparkPost.
-            </small>
+        <small>This is a SendGrid to SparkPost template translation service. From here you can translate a template
+          from file or migrate one directly from your SendGrid account into SparkPost.
+        </small>
         </p>
         <p>
-            <a class="btn btn-success btn-sml" href="migrate.html" role="button">MIGRATE A TEMPLATE &raquo;</a>
-            <a class="btn btn-success btn-sml" href="translate.html" role="button">TRANSLATE TEMPLATE TEXT &raquo;</a>
+        <a class="btn btn-success btn-sml" href="migrate.html" role="button">MIGRATE A TEMPLATE &raquo;</a>
+        <a class="btn btn-success btn-sml" href="translate.html" role="button">TRANSLATE TEMPLATE TEXT &raquo;</a>
         </p>
-    </div>
-    <div class="row">
+      </div>
+      <div class="row">
         <div class="col-sm-6">
-            <h4 class="pull-center">Transactional Templates</h4>
-            <table class="table table-striped">
-                <tr>
-                    <td>Supported features</td>
-                    <td>Unsupported features</td>
-                </tr>
-                <tr>
-                    <td>
-                        <ul class="supported">
-                            <li><%subject%></li>
-                            <li><%body%></li>
-                            <li><%asm_global_unsubscribe_url%><br/>
-                              <small>Note: You'll need to replace <code>?</code> in <code>&lt;a href="?" data-msys-unsubscribe="1"&gt;unsubs&lt;/a&gt;</code> after translation. </small>
-                            </li>
-                            <li>Custom delimited variables<br/>
-                                <small>
-                                    You need to provide the custom delimiters during translation.
-                                    <br/>Only one type of delimiter is supported.
-                                </small>
-                            </li>
-                        </ul>
+          <h4 class="pull-center">Transactional Templates</h4>
+          <table class="table table-striped">
+            <tr>
+              <td>Supported features</td>
+              <td>Unsupported features</td>
+            </tr>
+            <tr>
+              <td>
+                <ul class="supported">
+                  <li><code>&lt;%subject%&gt;</code></li>
+                  <li><code>&lt;%body%&gt;</code></li>
+                  <li><code>&lt;%asm_global_unsubscribe_url%&gt;</code><br/>
+                    <small>Note: You'll need to replace <code>?</code> in <code>&lt;a href="?" data-msys-unsubscribe="1"&gt;unsubs&lt;/a&gt;</code> after translation. </small>
+                  </li>
+                  <li>Custom delimited variables<br/>
+                    <small>
+                      You need to provide your chosen delimiter during translation.
+                      <br/>Only one delimiter is supported in each template.
+                    </small>
+                  </li>
+                </ul>
 
-                    </td>
-                    <td>
-                        <ul class="unsupported">
-                            <li><%asm_group_unsubscribe_url%></li>
-                            <li><%asm_preferences_url%></li>
-                        </ul>
-                    </td>
+              </td>
+              <td>
+                <ul class="unsupported">
+                  <li><code>&lt;%asm_group_unsubscribe_url%&gt;</code></li>
+                  <li><code>&lt;%asm_preferences_url%&gt;</code></li>
+                  <li>Sections</li>
+                </ul>
+              </td>
 
-                </tr>
-            </table>
+            </tr>
+          </table>
         </div>
         <div class="col-sm-6">
-            <h4 class="pull-center">Marketing Campaign Templates</h4>
-            <table class="table table-striped">
-                <tr>
-                    <td>Supported features</td>
-                    <td>Unsupported features</td>
-                </tr>
-                <tr>
-                    <td>
-                        <ul class="supported">
-                            <li>Sender Fields<br/>
-                                <small>[Sender_Name], [Sender_Address], [Sender_City], [Sender_State], [Sender_Zip]
-                                </small>
-                            </li>
-                            <li>[Unsubscribe]<br/>
-                              <small>Note: You'll need to replace <code>?</code> in <code>&lt;a href="?" data-msys-unsubscribe="1"&gt;unsubs&lt;/a&gt;</code> after translation. </small>
-                            </li>
-                            <li>[Weblink]</li>
-                            <li>[%email%]</li>
-                            <li>[%custom_field%], [%custom_field | default value%]</li>
-                        </ul>
-                    </td>
-                    <td>
-                        <ul class="unsupported">
-                            <li>[Unsubscribe_Preferences]</li>
-                        </ul>
-                    </td>
+          <h4 class="pull-center">Marketing Campaign Templates</h4>
+          <table class="table table-striped">
+            <tr>
+              <td>Supported features</td>
+              <td>Unsupported features</td>
+            </tr>
+            <tr>
+              <td>
+                <ul class="supported">
+                  <li>Sender Fields<br/>
+                    <small>[Sender_Name], [Sender_Address], [Sender_City], [Sender_State], [Sender_Zip]
+                    </small>
+                  </li>
+                  <li>[Unsubscribe]<br/>
+                    <small>Note: You'll need to replace <code>?</code> in <code>&lt;a href="?" data-msys-unsubscribe="1"&gt;unsubs&lt;/a&gt;</code> after translation. </small>
+                  </li>
+                  <li>[Weblink]</li>
+                  <li>[%email%]</li>
+                  <li>[%custom_field%], [%custom_field | default value%]</li>
+                </ul>
+              </td>
+              <td>
+                <ul class="unsupported">
+                  <li>[Unsubscribe_Preferences]</li>
+                </ul>
+              </td>
 
-                </tr>
-            </table>
+            </tr>
+          </table>
         </div>
+      </div>
+
     </div>
-  
-</div>
-</body>
+  </body>
 </html>

--- a/static/main.css
+++ b/static/main.css
@@ -151,3 +151,11 @@ hr {
   margin-top: 0;
   margin-bottom: 0;
 }
+
+#delimiterCtrls label {
+  padding-right: 1em;
+}
+
+.varExample {
+  font-style: italic;
+}

--- a/static/migrate.html
+++ b/static/migrate.html
@@ -81,16 +81,17 @@
                 </label>
               </div>
 
-              <div class="form-group" ng-show="!marketingTemplate">
-                  <label> Starting delimiter
-                    <input type="text" ng-model="startingDelimiter" />
-                  </label>
-                  <label> Has ending delimiter?
-                    <input type="checkbox" ng-model="endingDelimiter" name="endingDelimiter" id="endingDelimiter">
-                  </label>
-                  <div ng-show="startingDelimiter">
-                    Example: <strong>{{startingDelimiter}}tag{{ endingDelimiter ? startingDelimiter : null}}</strong>
-                  </div>
+              <div class="form-group" id="delimiterCtrls" ng-show="!marketingTemplate">
+                <label>Delimiter:
+                    <input type="text" size="2" ng-model="startingDelimiter" />
+                </label>
+                <label>
+                  <input type="checkbox" ng-model="endingDelimiter" name="endingDelimiter" id="endingDelimiter">
+                  Ending delimiter?
+                </label>
+                <span class="varExample">
+                (Example: <strong>{{startingDelimiter}}variable{{ endingDelimiter ? startingDelimiter : null}}</strong>)
+                </span>
               </div>
 
               <label for="sgTpl">SendGrid {{ marketingTemplate ? 'Campaign' : 'Template' }} ID <span class="text-warning" ng-show="migrateFrm.sgTpl.$touched && migrateFrm.sgTpl.$invalid">1+ chars required</span></label>

--- a/static/migrate.js
+++ b/static/migrate.js
@@ -8,12 +8,14 @@ migrationControllers.controller('MigrateControl', ['$scope', '$http', '$log',
     $scope.loading = false;
     $scope.sgAPIKey = '';
     $scope.sgTpl = '';
-    $scope.startingDelimiter = null;
     $scope.marketingTemplate = false;
     $scope.spAPIKey = '';
     $scope.useHerokuSPAPIKey = false;
     $scope.useSandboxDomain = true;
     $scope.sandboxDomain = 'sparkpostbox.com'; //TODO make it configurable?
+
+    $scope.startingDelimiter = '%';
+    $scope.endingDelimiter = true;
 
     $scope.$watch('marketingTemplate', function (newValue) {
       if (!newValue) {

--- a/static/migrate.js
+++ b/static/migrate.js
@@ -34,6 +34,7 @@ migrationControllers.controller('MigrateControl', ['$scope', '$http', '$log',
         endingDelimiter: !$scope.marketingTemplate && $scope.endingDelimiter ? $scope.startingDelimiter : undefined
       };
 
+      clearAlerts();
       $http({
         method: 'POST',
         url: '/api/migrate',
@@ -54,6 +55,10 @@ migrationControllers.controller('MigrateControl', ['$scope', '$http', '$log',
             console.error(e);
             link = '';
           }
+
+          result.data.warnings.forEach(function(warning) {
+            showWarning(warning);
+          });
 
           showInfo('Migration of ' + $scope.sgTpl + ' succeeded! ' + link);
         }
@@ -76,6 +81,10 @@ migrationControllers.controller('MigrateControl', ['$scope', '$http', '$log',
     $scope.alerts = [];
     $scope.closeAlert = function (idx) {
       $scope.alerts.splice(idx, 1);
+    };
+
+    function clearAlerts() {
+      $scope.alerts = [];
     };
 
     function showInfo(msg) {

--- a/static/translate.html
+++ b/static/translate.html
@@ -66,16 +66,17 @@
                 Marketing Template
               </label>
             </div>
-            <div ng-show="!marketingTemplate">
-                  <label> Starting delimiter
-                    <input type="text" ng-model="startingDelimiter" />
-                  </label>
-                  <label> Has ending delimiter?
-                    <input type="checkbox" ng-model="endingDelimiter" name="endingDelimiter" id="endingDelimiter">
-                  </label>
-                <div ng-show="startingDelimiter">
-                  Example: <strong>{{startingDelimiter}}tag{{ endingDelimiter ? startingDelimiter : null}}</strong>
-                </div>
+            <div id="delimiterCtrls" ng-show="!marketingTemplate">
+              <label>Delimiter:
+                  <input type="text" size="2" ng-model="startingDelimiter" />
+              </label>
+              <label>
+                <input type="checkbox" ng-model="endingDelimiter" name="endingDelimiter" id="endingDelimiter">
+                Ending delimiter?
+              </label>
+              <span class="varExample">
+              (Example: <strong>{{startingDelimiter}}variable{{ endingDelimiter ? startingDelimiter : null}}</strong>)
+              </span>
             </div>
           </div>
           <div class="col-md-6">

--- a/static/translate.js
+++ b/static/translate.js
@@ -11,6 +11,9 @@ translationControllers.controller('TranslatorControl', ['$scope', '$http', '$log
     $scope.spEditor = null;
     $scope.marketingTemplate = false;
 
+    $scope.startingDelimiter = '%';
+    $scope.endingDelimiter = true;
+
     function configureEditor(editor) {
       // Disable Ctrl-L binding - it clashes with a common browser keyboard shortcut
       editor.commands.addCommand({
@@ -46,7 +49,6 @@ translationControllers.controller('TranslatorControl', ['$scope', '$http', '$log
         showError('Empty SendGrid Template');
         return;
       }
-      console.log($scope.startingDelimiter);
       $scope.spEditor.setValue('');
       $scope.loading = true;
       clearAlerts();

--- a/static/translate.js
+++ b/static/translate.js
@@ -49,6 +49,7 @@ translationControllers.controller('TranslatorControl', ['$scope', '$http', '$log
       console.log($scope.startingDelimiter);
       $scope.spEditor.setValue('');
       $scope.loading = true;
+      clearAlerts();
       $http({
         method: 'POST',
         url: '/api/translate',
@@ -64,13 +65,14 @@ translationControllers.controller('TranslatorControl', ['$scope', '$http', '$log
         if (result.errors) {
           console.log('Error: ' + JSON.stringify(result.errors, null, '  '));
         } else {
-          clearAlerts();
           showInfo('Translation succeeded!');
           $scope.spEditor.setValue(result.data.sparkPostTemplate);
+          result.data.warnings.forEach(function(warning) {
+            showWarning(warning);
+          });
         }
       }).catch(function(err) {
         if (err.data.errors) {
-          clearAlerts();
           err.data.errors.forEach(function(error) {
             showSyntaxError(error.message);
           });


### PR DESCRIPTION
- Add warnings about unsupported syntax
- Exercise each piece of syntax through translation and migration
- Display details of migration-time API errors from SparkPost and SendGrid
- Clean up supported syntax list
- Clean up transactional delimiter form fields
